### PR TITLE
add Android client ID to google sign in logic

### DIFF
--- a/helpers/userAuth.js
+++ b/helpers/userAuth.js
@@ -141,16 +141,22 @@ const forgotPassword = async (req, res) => {
   const token = userRecord ? generatePasswordResetToken(userRecord) : null;
 
   const transporter = nodemailer.createTransport({
-    service: "Gmail",
+    host: "smtp.gmail.com",
+    port: 465,
+    secure: true,
     auth: {
+      type: "OAuth2",
       user: process.env.GMAIL_USERNAME,
-      pass: process.env.GMAIL_PASSWORD,
+      clientId: process.env.GMAIL_CLIENT_ID,
+      clientSecret: process.env.GMAIL_SECRET,
+      refreshToken: process.env.GMAIL_REFRESH_TOKEN,
+      accessToken: process.env.GMAIL_ACCESS_TOKEN,
+      expires: 3599,
     },
   });
-
   transporter.sendMail(
     {
-      from: "hello.xyzapp@gmail.com",
+      from: "team@rumble.capital",
       to: `${req.body.email}`,
       subject: "Push Pirates password reset request",
       date: new Date(),
@@ -159,7 +165,7 @@ const forgotPassword = async (req, res) => {
       <p>Good news! We processed your request to reset your password.</p>
       <p>Please click on the following link to create a new one. This one time use link will self-destruct in three hours.</p>
       <p>${process.env.API_URL}/reset-password?uid=${userRecord._id}&token=${token}</p>
-      <p>Best regards,<br>Push Pirates.</p>`,
+      <p>Best regards,<br>Push App Team.</p>`,
     },
     (error, info) => {
       if (error) {

--- a/helpers/userAuth.js
+++ b/helpers/userAuth.js
@@ -72,11 +72,15 @@ const userLogin = async (req, res) => {
 };
 
 const oAuthSignIn = async (req, res) => {
-  const { oAuthType, token } = req.body;
+  const { oAuthType, token, os } = req.body;
   switch (oAuthType) {
     case "google": {
       try {
-        const client = new OAuth2Client(process.env.GOOGLE_OATH_CLIENT_ID);
+        const clienID =
+          os === "android"
+            ? process.env.GOOGLE_SIGN_IN_CLIENT_ID_ANDROID
+            : process.env.GOOGLE_SIGN_IN_CLIENT_ID_IOS;
+        const client = new OAuth2Client(clienID);
         const verify = async () => {
           const ticket = await client.verifyIdToken({
             idToken: token,

--- a/server.js
+++ b/server.js
@@ -39,7 +39,7 @@ app.use(bodyParser.urlencoded({ extended: true })); //allows accessto URL params
 // Handle user signup and login:
 app.post("/login", userLogin);
 app.post("/signup", validateInput(["password", "email"]), userSignUp);
-app.post("/sign-in-oath", oAuthSignIn);
+app.post("/sign-in-oauth", oAuthSignIn);
 
 // Handle password reset:
 app.get("/reset-password", (_, res) => res.sendFile(__dirname + "/assets/password-reset.html"));


### PR DESCRIPTION
GOOGLE_SIGN_IN_CLIENT_ID_IOS and GOOGLE_SIGN_IN_CLIENT_ID_IOS needs to be added to .env file. they can be found from  https://console.developers.google.com/apis/credentials using team@rumble.capital account